### PR TITLE
fix: sftp fastGet download - files which size is greater than 64KB are corrupted

### DIFF
--- a/sftp.js
+++ b/sftp.js
@@ -75,7 +75,7 @@ module.exports = (...params) => class FtpPort extends require('./base')(...param
                     const localFile = params?.localFile || uuid();
                     const localFilePath = path.join(this.workDir, localFile);
                     return new Promise((resolve, reject) =>
-                        sftp.fastGet(params.remoteFile, localFilePath, {}, e => {
+                        sftp.fastGet(params.remoteFile, localFilePath, {chunkSize: 31952}, e => {
                             if (e) return reject(this.errors.ftpPort(e));
                             if (!params?.localFile) {
                                 const file = fs.readFileSync(localFilePath);

--- a/sftp.js
+++ b/sftp.js
@@ -75,7 +75,7 @@ module.exports = (...params) => class FtpPort extends require('./base')(...param
                     const localFile = params?.localFile || uuid();
                     const localFilePath = path.join(this.workDir, localFile);
                     return new Promise((resolve, reject) =>
-                        sftp.fastGet(params.remoteFile, localFilePath, {chunkSize: 31952}, e => {
+                        sftp.fastGet(params.remoteFile, localFilePath, {...this?.config?.fastGet?.options}, e => {
                             if (e) return reject(this.errors.ftpPort(e));
                             if (!params?.localFile) {
                                 const file = fs.readFileSync(localFilePath);


### PR DESCRIPTION

Related issue: https://github.com/mscdex/ssh2/issues/1166